### PR TITLE
terraform depends_on: before/after fix

### DIFF
--- a/_posts/2020-05-12-terraform-implicit-explicit-dependencies-between-resources.markdown
+++ b/_posts/2020-05-12-terraform-implicit-explicit-dependencies-between-resources.markdown
@@ -184,7 +184,7 @@ Let's try to regenerate the graph again:
 
 ![Second Dependency Graph - with explicit dependency](/images/terraform-implicit-explicit-dependencies-between-resources/graph-with-depends-on.jpg)
 
-As you can see on the graph, now the dependency is explicit, and it's easy for Terraform to know that it must delete the association between NIC and ASG before deleting the virtual machine resources.
+As you can see on the graph, now the dependency is explicit, and it's easy for Terraform to know that it must delete the association between NIC and ASG after deleting the virtual machine resources.
 
 Bug fixed! :-)
 


### PR DESCRIPTION
Update `2020-05-12-terraform-implicit-explicit-dependencies-between-resources.markdown`

The two paragraphs of the "Solving the issue" section conflict:

> We can make sure that the association is always created before the virtual machine is, and that the **virtual machine is always deleted before the association** is by adding a `depends_on` block on the virtual machine resources:
[...]
> and it's easy for Terraform to know that it must **delete the association between NIC and ASG before deleting the virtual machine** resources.

I believe the first is correct and the second is in error.